### PR TITLE
Add tree quine in Python

### DIFF
--- a/Python/quine.py
+++ b/Python/quine.py
@@ -1,0 +1,15 @@
+###
+_='     '
+Me=     '###\n'#
+rr=     '_=%r\nMe=%12r'
+y_=     '#\nrr=%20r\ny_=%26r'#
+Ch=     '#\nCh=%34r\nri=%r\nst=%r#%c'
+ri='\nma=%r#by D1N0\ns_=%14r;print((Me+rr+y'
+st='_+Ch#\n+ri%s+st+ma+s_)%%(_,Me,rr,##\ny_,%sCh,'#⭐
+ma='ri,st,11088\n,ma%s,s_,_,#\n_,_%'#by D1N0
+s_=     's,\n_))';print((Me+rr+y_+Ch#
++ri     +st+ma+s_)%(_,Me,rr,##
+y_,     Ch,ri,st,11088
+,ma     ,s_,_,#
+_,_     ,
+_))

--- a/Python/quine.py
+++ b/Python/quine.py
@@ -4,12 +4,12 @@ Me=     '###\n'#
 rr=     '_=%r\nMe=%12r'
 y_=     '#\nrr=%20r\ny_=%26r'#
 Ch=     '#\nCh=%34r\nri=%r\nst=%r#%c'
-ri='\nma=%r#by D1N0\ns_=%14r;print((Me+rr+y'
-st='_+Ch#\n+ri%s+st+ma+s_)%%(_,Me,rr,##\ny_,%sCh,'#⭐
-ma='ri,st,11088\n,ma%s,s_,_,#\n_,_%'#by D1N0
-s_=     's,\n_))';print((Me+rr+y_+Ch#
-+ri     +st+ma+s_)%(_,Me,rr,##
-y_,     Ch,ri,st,11088
-,ma     ,s_,_,#
+ri='\nma=%r# by D1N0\ns_=%17r;print((Me+rr+'
+st='y_+\nCh+%sri+st+ma+s_)%%(_,Me,rr,\ny_,%sCh,'#⭐
+ma='ri,st,72*154\n,ma%s,s_,_,##\n_'# by D1N0
+s_=     ',_%s,\n_))';print((Me+rr+y_+
+Ch+     ri+st+ma+s_)%(_,Me,rr,
+y_,     Ch,ri,st,72*154
+,ma     ,s_,_,##
 _,_     ,
 _))


### PR DESCRIPTION
Add tree shaped quine code in python
The execution result is the same as the code
```
###
_='     '
Me=     '###\n'#
rr=     '_=%r\nMe=%12r'
y_=     '#\nrr=%20r\ny_=%26r'#
Ch=     '#\nCh=%34r\nri=%r\nst=%r#%c'
ri='\nma=%r# by D1N0\ns_=%17r;print((Me+rr+'
st='y_+\nCh+%sri+st+ma+s_)%%(_,Me,rr,\ny_,%sCh,'#⭐
ma='ri,st,72*154\n,ma%s,s_,_,##\n_'# by D1N0
s_=     ',_%s,\n_))';print((Me+rr+y_+
Ch+     ri+st+ma+s_)%(_,Me,rr,
y_,     Ch,ri,st,72*154
,ma     ,s_,_,##
_,_     ,
_))
```
![image](https://user-images.githubusercontent.com/63863258/103131287-82264a00-46e3-11eb-8c7b-2eefe87c645c.png)
